### PR TITLE
Per product pse digressive price ranges

### DIFF
--- a/Config/create.sql
+++ b/Config/create.sql
@@ -11,15 +11,20 @@ CREATE TABLE IF NOT EXISTS `digressive_price`
 (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `product_id` INTEGER NOT NULL,
+    `product_sale_elements_id` INTEGER,
     `price` FLOAT NOT NULL,
     `promo_price` FLOAT NOT NULL,
     `quantity_from` INTEGER NOT NULL,
     `quantity_to` INTEGER NOT NULL,
     PRIMARY KEY (`id`),
     INDEX `FI_product_digressive` (`product_id`),
+    INDEX `FI_product_sale_elements_digressive` (`product_sale_elements_id`),
     CONSTRAINT `fk_product_digressive`
         FOREIGN KEY (`product_id`)
-        REFERENCES `product` (`id`)
+        REFERENCES `product` (`id`),
+    CONSTRAINT `fk_product_sale_elements_digressive`
+        FOREIGN KEY (`product_sale_elements_id`)
+        REFERENCES `product_sale_elements` (`id`)
 ) ENGINE=InnoDB;
 
 # This restores the fkey checks, after having unset them earlier

--- a/Config/schema.xml
+++ b/Config/schema.xml
@@ -3,12 +3,16 @@
     <table name="digressive_price">
         <column name="id" autoIncrement="true" primaryKey="true" required="true" type="INTEGER" />
         <column name="product_id" required="true" type="INTEGER" />
+        <column name="product_sale_elements_id" required="false" type="INTEGER" />
         <column name="price" required="true" type="FLOAT" />
         <column name="promo_price" required="true" type="FLOAT" />
         <column name="quantity_from" required="true" type="INTEGER" />
         <column name="quantity_to" required="true" type="INTEGER" />
         <foreign-key foreignTable="product" name="fk_product_digressive">
             <reference local="product_id" foreign="id"/>
+        </foreign-key>
+        <foreign-key foreignTable="product_sale_elements" name="fk_product_sale_elements_digressive">
+            <reference local="product_sale_elements_id" foreign="id"/>
         </foreign-key>
     </table>
     <external-schema filename="local/config/schema.xml" referenceOnly="true" />

--- a/Config/thelia.sql
+++ b/Config/thelia.sql
@@ -13,15 +13,20 @@ CREATE TABLE `digressive_price`
 (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `product_id` INTEGER NOT NULL,
+    `product_sale_elements_id` INTEGER,
     `price` FLOAT NOT NULL,
     `promo_price` FLOAT NOT NULL,
     `quantity_from` INTEGER NOT NULL,
     `quantity_to` INTEGER NOT NULL,
     PRIMARY KEY (`id`),
     INDEX `FI_product_digressive` (`product_id`),
+    INDEX `FI_product_sale_elements_digressive` (`product_sale_elements_id`),
     CONSTRAINT `fk_product_digressive`
         FOREIGN KEY (`product_id`)
-        REFERENCES `product` (`id`)
+        REFERENCES `product` (`id`),
+    CONSTRAINT `fk_product_sale_elements_digressive`
+        FOREIGN KEY (`product_sale_elements_id`)
+        REFERENCES `product_sale_elements` (`id`)
 ) ENGINE=InnoDB;
 
 # This restores the fkey checks, after having unset them earlier

--- a/Controller/DigressivePriceController.php
+++ b/Controller/DigressivePriceController.php
@@ -42,6 +42,7 @@ class DigressivePriceController extends BaseAdminController
             // Dispatch create
             $event = new DigressivePriceEvent(
                 $form->get('productId')->getData(),
+                $form->get('productSaleElementsId')->getData(),
                 $form->get('price')->getData(),
                 $form->get('promo')->getData(),
                 $form->get('quantityFrom')->getData(),
@@ -82,6 +83,7 @@ class DigressivePriceController extends BaseAdminController
             $event = new DigressivePriceFullEvent(
                 $form->get('id')->getData(),
                 $form->get('productId')->getData(),
+                $form->get('productSaleElementsId')->getData(),
                 $form->get('price')->getData(),
                 $form->get('promo')->getData(),
                 $form->get('quantityFrom')->getData(),

--- a/Event/DigressivePriceEvent.php
+++ b/Event/DigressivePriceEvent.php
@@ -13,6 +13,7 @@ class DigressivePriceEvent extends ActionEvent
 {
 
     protected $productId;
+    protected $productSaleElementsId;
     protected $price;
     protected $promoPrice;
     protected $quantityFrom;
@@ -20,12 +21,14 @@ class DigressivePriceEvent extends ActionEvent
 
     public function __construct(
         $productId,
+        $productSaleElementsId,
         $price,
         $promoPrice,
         $quantityFrom,
         $quantityTo
     ) {
         $this->productId = $productId;
+        $this->productSaleElementsId = $productSaleElementsId;
         $this->price = $price;
         $this->promoPrice = $promoPrice;
         $this->quantityFrom = $quantityFrom;
@@ -46,6 +49,22 @@ class DigressivePriceEvent extends ActionEvent
     public function setProductId($productId)
     {
         $this->productId = $productId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getProductSaleElementsId()
+    {
+        return $this->productSaleElementsId;
+    }
+
+    /**
+     * @param mixed $productSaleElementsId
+     */
+    public function setProductSaleElementsId($productSaleElementsId)
+    {
+        $this->productSaleElementsId = $productSaleElementsId;
     }
 
     /**

--- a/Event/DigressivePriceFullEvent.php
+++ b/Event/DigressivePriceFullEvent.php
@@ -15,6 +15,7 @@ class DigressivePriceFullEvent extends DigressivePriceEvent
     public function __construct(
         $id,
         $productId,
+        $productSaleElementsId,
         $price,
         $promoPrice,
         $quantityFrom,
@@ -22,6 +23,7 @@ class DigressivePriceFullEvent extends DigressivePriceEvent
     ) {
         $this->id = $id;
         $this->productId = $productId;
+        $this->productSaleElementsId = $productSaleElementsId;
         $this->price = $price;
         $this->promoPrice = $promoPrice;
         $this->quantityFrom = $quantityFrom;

--- a/Form/CreateDigressivePriceForm.php
+++ b/Form/CreateDigressivePriceForm.php
@@ -37,6 +37,17 @@ class CreateDigressivePriceForm extends BaseForm
             )
         )
         ->add(
+            "productSaleElementsId",
+            "number",
+            array(
+                "label" => $this->translator->trans(
+                    'product sale elements ID',
+                    [],
+                    DigressivePrice::DOMAIN.'.bo.default'
+                )
+            )
+        )
+        ->add(
             "quantityFrom",
             "number",
             array(
@@ -152,8 +163,10 @@ class CreateDigressivePriceForm extends BaseForm
     public function notSurround($value, ExecutionContextInterface $context, $isUpdating = false)
     {
         // Check if the values are around FROM and TO quantities of an existing digressive price of the current product
+        // (or product sale elements)
         $digressivePricesQuery = DigressivePriceQuery::create()
             ->filterByProductId($this->getForm()->getData()['productId'])
+            ->filterByProductSaleElementsId($this->getForm()->getData()['productSaleElementsId'])
             ->filterByQuantityFrom($this->getForm()->getData()['quantityFrom'], Criteria::GREATER_EQUAL)
             ->filterByQuantityTo($value, Criteria::LESS_EQUAL);
 
@@ -180,8 +193,10 @@ class CreateDigressivePriceForm extends BaseForm
     public function inRangeQuery($value, $isUpdating)
     {
         // Check if the value is between FROM and TO quantities of an existing digressive price of the current product
+        // (or product sale elements)
         $digressivePricesQuery = DigressivePriceQuery::create()
             ->filterByProductId($this->getForm()->getData()['productId'])
+            ->filterByProductSaleElementsId($this->getForm()->getData()['productSaleElementsId'])
             ->filterByQuantityFrom($value, Criteria::LESS_EQUAL)
             ->filterByQuantityTo($value, Criteria::GREATER_EQUAL);
 

--- a/Form/DeleteDigressivePriceForm.php
+++ b/Form/DeleteDigressivePriceForm.php
@@ -30,6 +30,17 @@ class DeleteDigressivePriceForm extends BaseForm
             )
         )
         ->add(
+            "productSaleElementsId",
+            "number",
+            array(
+                "label" => $this->translator->trans(
+                    'product sale elements ID',
+                    [],
+                    DigressivePrice::DOMAIN.'.bo.default'
+                )
+            )
+        )
+        ->add(
             "id",
             "number",
             array(

--- a/I18n/backOffice/default/en_US.php
+++ b/I18n/backOffice/default/en_US.php
@@ -2,6 +2,7 @@
 return array(
     // BO display
     'Digressive price' => 'Digressive price',
+    'Attribute combination' => 'Attribute combination',
     'From' => 'From',
     'To' => 'To',
     'Price w/o taxes' => 'Price w/o taxes',
@@ -12,9 +13,11 @@ return array(
     'Remove' => 'Remove',
 
     // Form labels & errors
+    'All' => 'All',
     'FROM {quantity}' => 'FROM {quantity}',
     'TO {quantity}' => 'TO {quantity}',
     'product ID' => 'product ID',
+    'product sale elements ID' => 'product sale elements ID',
     'The end of range must be greater than the beginning' => 'The end of range must be greater than the beginning',
     'Your new range surrounds an existing one' => 'Your new range surrounds an existing one',
     'Your new range begins in another one' => 'Your new range surrounds an existing one',

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -2,6 +2,7 @@
 return array(
     // BO display
     'Digressive price' => 'Prix dégressif',
+    'Attribute combination' => 'Combinaison de déclinaisons',
     'Quantity' => 'Quantité',
     'From' => 'De',
     'To' => 'A',
@@ -13,9 +14,11 @@ return array(
     'Remove' => 'Supprimer',
 
     // Form labels & errors
+    'All' => 'Toutes',
     'FROM {quantity}' => 'DE {quantité}',
     'TO {quantity}' => 'A {quantité}',
     'product ID' => 'ID du produit',
+    'product sale elements ID' => 'ID de la combinaison de déclinaisons du produit',
     'The end of range must be greater than the beginning' => 'La quantité de fin de tranche doit être inférieure à celle de début',
     'Your new range surrounds an existing one' => 'Votre tranche de quantités en englobe une autre',
     'Your new range begins in another one' => 'Votre tranche de quantités débute dans une autre',

--- a/Loop/DigressiveLoop.php
+++ b/Loop/DigressiveLoop.php
@@ -24,16 +24,24 @@ class DigressiveLoop extends BaseI18nLoop implements PropelSearchLoopInterface
 
     protected function getArgDefinitions()
     {
-        return new ArgumentCollection(Argument::createIntTypeArgument('product_id'));
+        return new ArgumentCollection(
+            Argument::createIntTypeArgument('product_id'),
+            Argument::createIntTypeArgument('product_sale_elements_id')
+        );
     }
 
     public function buildModelCriteria()
     {
         $productId = $this->getProductId();
+        $productSaleElementsId = $this->getProductSaleElementsId();
         $search = DigressivePriceQuery::create();
 
         if (!is_null($productId)) {
             $search->filterByProductId($productId);
+        }
+
+        if (!is_null($productSaleElementsId)) {
+            $search->filterByProductSaleElementsId($productSaleElementsId);
         }
 
         return $search;
@@ -62,6 +70,7 @@ class DigressiveLoop extends BaseI18nLoop implements PropelSearchLoopInterface
             $loopResultRow
                     ->set("ID", $digressivePrice->getId())
                     ->set("PRODUCT_ID", $productId)
+                    ->set("PRODUCT_SALE_ELEMENTS_ID", $digressivePrice->getProductSaleElementsId())
                     ->set("QUANTITY_FROM", $digressivePrice->getQuantityFrom())
                     ->set("QUANTITY_TO", $digressivePrice->getQuantityTo())
                     ->set("PRICE", $price)

--- a/Model/Base/DigressivePrice.php
+++ b/Model/Base/DigressivePrice.php
@@ -7,7 +7,9 @@ use \PDO;
 use DigressivePrice\Model\DigressivePriceQuery as ChildDigressivePriceQuery;
 use DigressivePrice\Model\Map\DigressivePriceTableMap;
 use DigressivePrice\Model\Thelia\Model\Product as ChildProduct;
+use DigressivePrice\Model\Thelia\Model\ProductSaleElements as ChildProductSaleElements;
 use DigressivePrice\Model\Thelia\Model\ProductQuery;
+use DigressivePrice\Model\Thelia\Model\ProductSaleElementsQuery;
 use Propel\Runtime\Propel;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
@@ -66,6 +68,12 @@ abstract class DigressivePrice implements ActiveRecordInterface
     protected $product_id;
 
     /**
+     * The value for the product_sale_elements_id field.
+     * @var        int
+     */
+    protected $product_sale_elements_id;
+
+    /**
      * The value for the price field.
      * @var        double
      */
@@ -93,6 +101,11 @@ abstract class DigressivePrice implements ActiveRecordInterface
      * @var        Product
      */
     protected $aProduct;
+
+    /**
+     * @var        ProductSaleElements
+     */
+    protected $aProductSaleElements;
 
     /**
      * Flag to prevent endless save loop, if this object is referenced
@@ -217,7 +230,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
         }
 
         if (null === $this->getPrimaryKey()
-            || null === $obj->getPrimaryKey()) {
+            || null === $obj->getPrimaryKey())  {
             return false;
         }
 
@@ -367,6 +380,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getId()
     {
+
         return $this->id;
     }
 
@@ -377,7 +391,19 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getProductId()
     {
+
         return $this->product_id;
+    }
+
+    /**
+     * Get the [product_sale_elements_id] column value.
+     *
+     * @return   int
+     */
+    public function getProductSaleElementsId()
+    {
+
+        return $this->product_sale_elements_id;
     }
 
     /**
@@ -387,6 +413,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getPrice()
     {
+
         return $this->price;
     }
 
@@ -397,6 +424,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getPromoPrice()
     {
+
         return $this->promo_price;
     }
 
@@ -407,6 +435,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getQuantityFrom()
     {
+
         return $this->quantity_from;
     }
 
@@ -417,6 +446,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function getQuantityTo()
     {
+
         return $this->quantity_to;
     }
 
@@ -465,6 +495,31 @@ abstract class DigressivePrice implements ActiveRecordInterface
 
         return $this;
     } // setProductId()
+
+    /**
+     * Set the value of [product_sale_elements_id] column.
+     *
+     * @param      int $v new value
+     * @return   \DigressivePrice\Model\DigressivePrice The current object (for fluent API support)
+     */
+    public function setProductSaleElementsId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->product_sale_elements_id !== $v) {
+            $this->product_sale_elements_id = $v;
+            $this->modifiedColumns[DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID] = true;
+        }
+
+        if ($this->aProductSaleElements !== null && $this->aProductSaleElements->getId() !== $v) {
+            $this->aProductSaleElements = null;
+        }
+
+
+        return $this;
+    } // setProductSaleElementsId()
 
     /**
      * Set the value of [price] column.
@@ -585,22 +640,27 @@ abstract class DigressivePrice implements ActiveRecordInterface
     public function hydrate($row, $startcol = 0, $rehydrate = false, $indexType = TableMap::TYPE_NUM)
     {
         try {
+
+
             $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : DigressivePriceTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
             $this->id = (null !== $col) ? (int) $col : null;
 
             $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : DigressivePriceTableMap::translateFieldName('ProductId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->product_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : DigressivePriceTableMap::translateFieldName('Price', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : DigressivePriceTableMap::translateFieldName('ProductSaleElementsId', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->product_sale_elements_id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : DigressivePriceTableMap::translateFieldName('Price', TableMap::TYPE_PHPNAME, $indexType)];
             $this->price = (null !== $col) ? (double) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : DigressivePriceTableMap::translateFieldName('PromoPrice', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : DigressivePriceTableMap::translateFieldName('PromoPrice', TableMap::TYPE_PHPNAME, $indexType)];
             $this->promo_price = (null !== $col) ? (double) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : DigressivePriceTableMap::translateFieldName('QuantityFrom', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : DigressivePriceTableMap::translateFieldName('QuantityFrom', TableMap::TYPE_PHPNAME, $indexType)];
             $this->quantity_from = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : DigressivePriceTableMap::translateFieldName('QuantityTo', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : DigressivePriceTableMap::translateFieldName('QuantityTo', TableMap::TYPE_PHPNAME, $indexType)];
             $this->quantity_to = (null !== $col) ? (int) $col : null;
             $this->resetModified();
 
@@ -610,7 +670,8 @@ abstract class DigressivePrice implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 6; // 6 = DigressivePriceTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 7; // 7 = DigressivePriceTableMap::NUM_HYDRATE_COLUMNS.
+
         } catch (Exception $e) {
             throw new PropelException("Error populating \DigressivePrice\Model\DigressivePrice object", 0, $e);
         }
@@ -633,6 +694,9 @@ abstract class DigressivePrice implements ActiveRecordInterface
     {
         if ($this->aProduct !== null && $this->product_id !== $this->aProduct->getId()) {
             $this->aProduct = null;
+        }
+        if ($this->aProductSaleElements !== null && $this->product_sale_elements_id !== $this->aProductSaleElements->getId()) {
+            $this->aProductSaleElements = null;
         }
     } // ensureConsistency
 
@@ -674,6 +738,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
         if ($deep) {  // also de-associate any related objects?
 
             $this->aProduct = null;
+            $this->aProductSaleElements = null;
         } // if (deep)
     }
 
@@ -797,6 +862,13 @@ abstract class DigressivePrice implements ActiveRecordInterface
                 $this->setProduct($this->aProduct);
             }
 
+            if ($this->aProductSaleElements !== null) {
+                if ($this->aProductSaleElements->isModified() || $this->aProductSaleElements->isNew()) {
+                    $affectedRows += $this->aProductSaleElements->save($con);
+                }
+                $this->setProductSaleElements($this->aProductSaleElements);
+            }
+
             if ($this->isNew() || $this->isModified()) {
                 // persist changes
                 if ($this->isNew()) {
@@ -809,6 +881,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
             }
 
             $this->alreadyInSave = false;
+
         }
 
         return $affectedRows;
@@ -839,6 +912,9 @@ abstract class DigressivePrice implements ActiveRecordInterface
         if ($this->isColumnModified(DigressivePriceTableMap::PRODUCT_ID)) {
             $modifiedColumns[':p' . $index++]  = 'PRODUCT_ID';
         }
+        if ($this->isColumnModified(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID)) {
+            $modifiedColumns[':p' . $index++]  = 'PRODUCT_SALE_ELEMENTS_ID';
+        }
         if ($this->isColumnModified(DigressivePriceTableMap::PRICE)) {
             $modifiedColumns[':p' . $index++]  = 'PRICE';
         }
@@ -867,6 +943,9 @@ abstract class DigressivePrice implements ActiveRecordInterface
                         break;
                     case 'PRODUCT_ID':
                         $stmt->bindValue($identifier, $this->product_id, PDO::PARAM_INT);
+                        break;
+                    case 'PRODUCT_SALE_ELEMENTS_ID':
+                        $stmt->bindValue($identifier, $this->product_sale_elements_id, PDO::PARAM_INT);
                         break;
                     case 'PRICE':
                         $stmt->bindValue($identifier, $this->price, PDO::PARAM_STR);
@@ -949,15 +1028,18 @@ abstract class DigressivePrice implements ActiveRecordInterface
                 return $this->getProductId();
                 break;
             case 2:
-                return $this->getPrice();
+                return $this->getProductSaleElementsId();
                 break;
             case 3:
-                return $this->getPromoPrice();
+                return $this->getPrice();
                 break;
             case 4:
-                return $this->getQuantityFrom();
+                return $this->getPromoPrice();
                 break;
             case 5:
+                return $this->getQuantityFrom();
+                break;
+            case 6:
                 return $this->getQuantityTo();
                 break;
             default:
@@ -991,10 +1073,11 @@ abstract class DigressivePrice implements ActiveRecordInterface
         $result = array(
             $keys[0] => $this->getId(),
             $keys[1] => $this->getProductId(),
-            $keys[2] => $this->getPrice(),
-            $keys[3] => $this->getPromoPrice(),
-            $keys[4] => $this->getQuantityFrom(),
-            $keys[5] => $this->getQuantityTo(),
+            $keys[2] => $this->getProductSaleElementsId(),
+            $keys[3] => $this->getPrice(),
+            $keys[4] => $this->getPromoPrice(),
+            $keys[5] => $this->getQuantityFrom(),
+            $keys[6] => $this->getQuantityTo(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1004,6 +1087,9 @@ abstract class DigressivePrice implements ActiveRecordInterface
         if ($includeForeignObjects) {
             if (null !== $this->aProduct) {
                 $result['Product'] = $this->aProduct->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
+            }
+            if (null !== $this->aProductSaleElements) {
+                $result['ProductSaleElements'] = $this->aProductSaleElements->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
             }
         }
 
@@ -1046,15 +1132,18 @@ abstract class DigressivePrice implements ActiveRecordInterface
                 $this->setProductId($value);
                 break;
             case 2:
-                $this->setPrice($value);
+                $this->setProductSaleElementsId($value);
                 break;
             case 3:
-                $this->setPromoPrice($value);
+                $this->setPrice($value);
                 break;
             case 4:
-                $this->setQuantityFrom($value);
+                $this->setPromoPrice($value);
                 break;
             case 5:
+                $this->setQuantityFrom($value);
+                break;
+            case 6:
                 $this->setQuantityTo($value);
                 break;
         } // switch()
@@ -1081,24 +1170,13 @@ abstract class DigressivePrice implements ActiveRecordInterface
     {
         $keys = DigressivePriceTableMap::getFieldNames($keyType);
 
-        if (array_key_exists($keys[0], $arr)) {
-            $this->setId($arr[$keys[0]]);
-        }
-        if (array_key_exists($keys[1], $arr)) {
-            $this->setProductId($arr[$keys[1]]);
-        }
-        if (array_key_exists($keys[2], $arr)) {
-            $this->setPrice($arr[$keys[2]]);
-        }
-        if (array_key_exists($keys[3], $arr)) {
-            $this->setPromoPrice($arr[$keys[3]]);
-        }
-        if (array_key_exists($keys[4], $arr)) {
-            $this->setQuantityFrom($arr[$keys[4]]);
-        }
-        if (array_key_exists($keys[5], $arr)) {
-            $this->setQuantityTo($arr[$keys[5]]);
-        }
+        if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
+        if (array_key_exists($keys[1], $arr)) $this->setProductId($arr[$keys[1]]);
+        if (array_key_exists($keys[2], $arr)) $this->setProductSaleElementsId($arr[$keys[2]]);
+        if (array_key_exists($keys[3], $arr)) $this->setPrice($arr[$keys[3]]);
+        if (array_key_exists($keys[4], $arr)) $this->setPromoPrice($arr[$keys[4]]);
+        if (array_key_exists($keys[5], $arr)) $this->setQuantityFrom($arr[$keys[5]]);
+        if (array_key_exists($keys[6], $arr)) $this->setQuantityTo($arr[$keys[6]]);
     }
 
     /**
@@ -1110,24 +1188,13 @@ abstract class DigressivePrice implements ActiveRecordInterface
     {
         $criteria = new Criteria(DigressivePriceTableMap::DATABASE_NAME);
 
-        if ($this->isColumnModified(DigressivePriceTableMap::ID)) {
-            $criteria->add(DigressivePriceTableMap::ID, $this->id);
-        }
-        if ($this->isColumnModified(DigressivePriceTableMap::PRODUCT_ID)) {
-            $criteria->add(DigressivePriceTableMap::PRODUCT_ID, $this->product_id);
-        }
-        if ($this->isColumnModified(DigressivePriceTableMap::PRICE)) {
-            $criteria->add(DigressivePriceTableMap::PRICE, $this->price);
-        }
-        if ($this->isColumnModified(DigressivePriceTableMap::PROMO_PRICE)) {
-            $criteria->add(DigressivePriceTableMap::PROMO_PRICE, $this->promo_price);
-        }
-        if ($this->isColumnModified(DigressivePriceTableMap::QUANTITY_FROM)) {
-            $criteria->add(DigressivePriceTableMap::QUANTITY_FROM, $this->quantity_from);
-        }
-        if ($this->isColumnModified(DigressivePriceTableMap::QUANTITY_TO)) {
-            $criteria->add(DigressivePriceTableMap::QUANTITY_TO, $this->quantity_to);
-        }
+        if ($this->isColumnModified(DigressivePriceTableMap::ID)) $criteria->add(DigressivePriceTableMap::ID, $this->id);
+        if ($this->isColumnModified(DigressivePriceTableMap::PRODUCT_ID)) $criteria->add(DigressivePriceTableMap::PRODUCT_ID, $this->product_id);
+        if ($this->isColumnModified(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID)) $criteria->add(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $this->product_sale_elements_id);
+        if ($this->isColumnModified(DigressivePriceTableMap::PRICE)) $criteria->add(DigressivePriceTableMap::PRICE, $this->price);
+        if ($this->isColumnModified(DigressivePriceTableMap::PROMO_PRICE)) $criteria->add(DigressivePriceTableMap::PROMO_PRICE, $this->promo_price);
+        if ($this->isColumnModified(DigressivePriceTableMap::QUANTITY_FROM)) $criteria->add(DigressivePriceTableMap::QUANTITY_FROM, $this->quantity_from);
+        if ($this->isColumnModified(DigressivePriceTableMap::QUANTITY_TO)) $criteria->add(DigressivePriceTableMap::QUANTITY_TO, $this->quantity_to);
 
         return $criteria;
     }
@@ -1174,6 +1241,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function isPrimaryKeyNull()
     {
+
         return null === $this->getId();
     }
 
@@ -1191,13 +1259,14 @@ abstract class DigressivePrice implements ActiveRecordInterface
     public function copyInto($copyObj, $deepCopy = false, $makeNew = true)
     {
         $copyObj->setProductId($this->getProductId());
+        $copyObj->setProductSaleElementsId($this->getProductSaleElementsId());
         $copyObj->setPrice($this->getPrice());
         $copyObj->setPromoPrice($this->getPromoPrice());
         $copyObj->setQuantityFrom($this->getQuantityFrom());
         $copyObj->setQuantityTo($this->getQuantityTo());
         if ($makeNew) {
             $copyObj->setNew(true);
-            $copyObj->setId(null); // this is a auto-increment column, so set to default value
+            $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
         }
     }
 
@@ -1233,7 +1302,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
     public function setProduct(ChildProduct $v = null)
     {
         if ($v === null) {
-            $this->setProductId(null);
+            $this->setProductId(NULL);
         } else {
             $this->setProductId($v->getId());
         }
@@ -1275,12 +1344,64 @@ abstract class DigressivePrice implements ActiveRecordInterface
     }
 
     /**
+     * Declares an association between this object and a ChildProductSaleElements object.
+     *
+     * @param                  ChildProductSaleElements $v
+     * @return                 \DigressivePrice\Model\DigressivePrice The current object (for fluent API support)
+     * @throws PropelException
+     */
+    public function setProductSaleElements(ChildProductSaleElements $v = null)
+    {
+        if ($v === null) {
+            $this->setProductSaleElementsId(NULL);
+        } else {
+            $this->setProductSaleElementsId($v->getId());
+        }
+
+        $this->aProductSaleElements = $v;
+
+        // Add binding for other direction of this n:n relationship.
+        // If this object has already been added to the ChildProductSaleElements object, it will not be re-added.
+        if ($v !== null) {
+            $v->addDigressivePrice($this);
+        }
+
+
+        return $this;
+    }
+
+
+    /**
+     * Get the associated ChildProductSaleElements object
+     *
+     * @param      ConnectionInterface $con Optional Connection object.
+     * @return                 ChildProductSaleElements The associated ChildProductSaleElements object.
+     * @throws PropelException
+     */
+    public function getProductSaleElements(ConnectionInterface $con = null)
+    {
+        if ($this->aProductSaleElements === null && ($this->product_sale_elements_id !== null)) {
+            $this->aProductSaleElements = ProductSaleElementsQuery::create()->findPk($this->product_sale_elements_id, $con);
+            /* The following can be used additionally to
+                guarantee the related object contains a reference
+                to this object.  This level of coupling may, however, be
+                undesirable since it could result in an only partially populated collection
+                in the referenced object.
+                $this->aProductSaleElements->addDigressivePrices($this);
+             */
+        }
+
+        return $this->aProductSaleElements;
+    }
+
+    /**
      * Clears the current object and sets all attributes to their default values
      */
     public function clear()
     {
         $this->id = null;
         $this->product_id = null;
+        $this->product_sale_elements_id = null;
         $this->price = null;
         $this->promo_price = null;
         $this->quantity_from = null;
@@ -1307,6 +1428,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
         } // if ($deep)
 
         $this->aProduct = null;
+        $this->aProductSaleElements = null;
     }
 
     /**
@@ -1335,6 +1457,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function postSave(ConnectionInterface $con = null)
     {
+
     }
 
     /**
@@ -1353,6 +1476,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function postInsert(ConnectionInterface $con = null)
     {
+
     }
 
     /**
@@ -1371,6 +1495,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function postUpdate(ConnectionInterface $con = null)
     {
+
     }
 
     /**
@@ -1389,6 +1514,7 @@ abstract class DigressivePrice implements ActiveRecordInterface
      */
     public function postDelete(ConnectionInterface $con = null)
     {
+
     }
 
 
@@ -1432,4 +1558,5 @@ abstract class DigressivePrice implements ActiveRecordInterface
 
         throw new BadMethodCallException(sprintf('Call to undefined method: %s.', $name));
     }
+
 }

--- a/Model/Base/DigressivePriceQuery.php
+++ b/Model/Base/DigressivePriceQuery.php
@@ -8,6 +8,7 @@ use DigressivePrice\Model\DigressivePrice as ChildDigressivePrice;
 use DigressivePrice\Model\DigressivePriceQuery as ChildDigressivePriceQuery;
 use DigressivePrice\Model\Map\DigressivePriceTableMap;
 use DigressivePrice\Model\Thelia\Model\Product;
+use DigressivePrice\Model\Thelia\Model\ProductSaleElements;
 use Propel\Runtime\Propel;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
@@ -24,6 +25,7 @@ use Propel\Runtime\Exception\PropelException;
  *
  * @method     ChildDigressivePriceQuery orderById($order = Criteria::ASC) Order by the id column
  * @method     ChildDigressivePriceQuery orderByProductId($order = Criteria::ASC) Order by the product_id column
+ * @method     ChildDigressivePriceQuery orderByProductSaleElementsId($order = Criteria::ASC) Order by the product_sale_elements_id column
  * @method     ChildDigressivePriceQuery orderByPrice($order = Criteria::ASC) Order by the price column
  * @method     ChildDigressivePriceQuery orderByPromoPrice($order = Criteria::ASC) Order by the promo_price column
  * @method     ChildDigressivePriceQuery orderByQuantityFrom($order = Criteria::ASC) Order by the quantity_from column
@@ -31,6 +33,7 @@ use Propel\Runtime\Exception\PropelException;
  *
  * @method     ChildDigressivePriceQuery groupById() Group by the id column
  * @method     ChildDigressivePriceQuery groupByProductId() Group by the product_id column
+ * @method     ChildDigressivePriceQuery groupByProductSaleElementsId() Group by the product_sale_elements_id column
  * @method     ChildDigressivePriceQuery groupByPrice() Group by the price column
  * @method     ChildDigressivePriceQuery groupByPromoPrice() Group by the promo_price column
  * @method     ChildDigressivePriceQuery groupByQuantityFrom() Group by the quantity_from column
@@ -44,11 +47,16 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildDigressivePriceQuery rightJoinProduct($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Product relation
  * @method     ChildDigressivePriceQuery innerJoinProduct($relationAlias = null) Adds a INNER JOIN clause to the query using the Product relation
  *
+ * @method     ChildDigressivePriceQuery leftJoinProductSaleElements($relationAlias = null) Adds a LEFT JOIN clause to the query using the ProductSaleElements relation
+ * @method     ChildDigressivePriceQuery rightJoinProductSaleElements($relationAlias = null) Adds a RIGHT JOIN clause to the query using the ProductSaleElements relation
+ * @method     ChildDigressivePriceQuery innerJoinProductSaleElements($relationAlias = null) Adds a INNER JOIN clause to the query using the ProductSaleElements relation
+ *
  * @method     ChildDigressivePrice findOne(ConnectionInterface $con = null) Return the first ChildDigressivePrice matching the query
  * @method     ChildDigressivePrice findOneOrCreate(ConnectionInterface $con = null) Return the first ChildDigressivePrice matching the query, or a new ChildDigressivePrice object populated from the query conditions when no match is found
  *
  * @method     ChildDigressivePrice findOneById(int $id) Return the first ChildDigressivePrice filtered by the id column
  * @method     ChildDigressivePrice findOneByProductId(int $product_id) Return the first ChildDigressivePrice filtered by the product_id column
+ * @method     ChildDigressivePrice findOneByProductSaleElementsId(int $product_sale_elements_id) Return the first ChildDigressivePrice filtered by the product_sale_elements_id column
  * @method     ChildDigressivePrice findOneByPrice(double $price) Return the first ChildDigressivePrice filtered by the price column
  * @method     ChildDigressivePrice findOneByPromoPrice(double $promo_price) Return the first ChildDigressivePrice filtered by the promo_price column
  * @method     ChildDigressivePrice findOneByQuantityFrom(int $quantity_from) Return the first ChildDigressivePrice filtered by the quantity_from column
@@ -56,6 +64,7 @@ use Propel\Runtime\Exception\PropelException;
  *
  * @method     array findById(int $id) Return ChildDigressivePrice objects filtered by the id column
  * @method     array findByProductId(int $product_id) Return ChildDigressivePrice objects filtered by the product_id column
+ * @method     array findByProductSaleElementsId(int $product_sale_elements_id) Return ChildDigressivePrice objects filtered by the product_sale_elements_id column
  * @method     array findByPrice(double $price) Return ChildDigressivePrice objects filtered by the price column
  * @method     array findByPromoPrice(double $promo_price) Return ChildDigressivePrice objects filtered by the promo_price column
  * @method     array findByQuantityFrom(int $quantity_from) Return ChildDigressivePrice objects filtered by the quantity_from column
@@ -148,7 +157,7 @@ abstract class DigressivePriceQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT ID, PRODUCT_ID, PRICE, PROMO_PRICE, QUANTITY_FROM, QUANTITY_TO FROM digressive_price WHERE ID = :p0';
+        $sql = 'SELECT ID, PRODUCT_ID, PRODUCT_SALE_ELEMENTS_ID, PRICE, PROMO_PRICE, QUANTITY_FROM, QUANTITY_TO FROM digressive_price WHERE ID = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -220,6 +229,7 @@ abstract class DigressivePriceQuery extends ModelCriteria
      */
     public function filterByPrimaryKey($key)
     {
+
         return $this->addUsingAlias(DigressivePriceTableMap::ID, $key, Criteria::EQUAL);
     }
 
@@ -232,6 +242,7 @@ abstract class DigressivePriceQuery extends ModelCriteria
      */
     public function filterByPrimaryKeys($keys)
     {
+
         return $this->addUsingAlias(DigressivePriceTableMap::ID, $keys, Criteria::IN);
     }
 
@@ -317,6 +328,49 @@ abstract class DigressivePriceQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(DigressivePriceTableMap::PRODUCT_ID, $productId, $comparison);
+    }
+
+    /**
+     * Filter the query on the product_sale_elements_id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByProductSaleElementsId(1234); // WHERE product_sale_elements_id = 1234
+     * $query->filterByProductSaleElementsId(array(12, 34)); // WHERE product_sale_elements_id IN (12, 34)
+     * $query->filterByProductSaleElementsId(array('min' => 12)); // WHERE product_sale_elements_id > 12
+     * </code>
+     *
+     * @see       filterByProductSaleElements()
+     *
+     * @param     mixed $productSaleElementsId The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildDigressivePriceQuery The current query, for fluid interface
+     */
+    public function filterByProductSaleElementsId($productSaleElementsId = null, $comparison = null)
+    {
+        if (is_array($productSaleElementsId)) {
+            $useMinMax = false;
+            if (isset($productSaleElementsId['min'])) {
+                $this->addUsingAlias(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $productSaleElementsId['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($productSaleElementsId['max'])) {
+                $this->addUsingAlias(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $productSaleElementsId['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $productSaleElementsId, $comparison);
     }
 
     /**
@@ -559,6 +613,81 @@ abstract class DigressivePriceQuery extends ModelCriteria
     }
 
     /**
+     * Filter the query by a related \DigressivePrice\Model\Thelia\Model\ProductSaleElements object
+     *
+     * @param \DigressivePrice\Model\Thelia\Model\ProductSaleElements|ObjectCollection $productSaleElements The related object(s) to use as filter
+     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildDigressivePriceQuery The current query, for fluid interface
+     */
+    public function filterByProductSaleElements($productSaleElements, $comparison = null)
+    {
+        if ($productSaleElements instanceof \DigressivePrice\Model\Thelia\Model\ProductSaleElements) {
+            return $this
+                ->addUsingAlias(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $productSaleElements->getId(), $comparison);
+        } elseif ($productSaleElements instanceof ObjectCollection) {
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+
+            return $this
+                ->addUsingAlias(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, $productSaleElements->toKeyValue('PrimaryKey', 'Id'), $comparison);
+        } else {
+            throw new PropelException('filterByProductSaleElements() only accepts arguments of type \DigressivePrice\Model\Thelia\Model\ProductSaleElements or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the ProductSaleElements relation
+     *
+     * @param     string $relationAlias optional alias for the relation
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return ChildDigressivePriceQuery The current query, for fluid interface
+     */
+    public function joinProductSaleElements($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('ProductSaleElements');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'ProductSaleElements');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the ProductSaleElements relation ProductSaleElements object
+     *
+     * @see useQuery()
+     *
+     * @param     string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return   \DigressivePrice\Model\Thelia\Model\ProductSaleElementsQuery A secondary query class using the current class as primary query
+     */
+    public function useProductSaleElementsQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinProductSaleElements($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'ProductSaleElements', '\DigressivePrice\Model\Thelia\Model\ProductSaleElementsQuery');
+    }
+
+    /**
      * Exclude object from result
      *
      * @param   ChildDigressivePrice $digressivePrice Object to remove from the list of results
@@ -619,16 +748,16 @@ abstract class DigressivePriceQuery extends ModelCriteria
      */
      public function delete(ConnectionInterface $con = null)
      {
-         if (null === $con) {
-             $con = Propel::getServiceContainer()->getWriteConnection(DigressivePriceTableMap::DATABASE_NAME);
-         }
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(DigressivePriceTableMap::DATABASE_NAME);
+        }
 
-         $criteria = $this;
+        $criteria = $this;
 
         // Set the correct dbName
         $criteria->setDbName(DigressivePriceTableMap::DATABASE_NAME);
 
-         $affectedRows = 0; // initialize var to track total num of affected rows
+        $affectedRows = 0; // initialize var to track total num of affected rows
 
         try {
             // use transaction because $criteria could contain info
@@ -636,7 +765,7 @@ abstract class DigressivePriceQuery extends ModelCriteria
             $con->beginTransaction();
 
 
-            DigressivePriceTableMap::removeInstanceFromPool($criteria);
+        DigressivePriceTableMap::removeInstanceFromPool($criteria);
 
             $affectedRows += ModelCriteria::delete($con);
             DigressivePriceTableMap::clearRelatedInstancePool();
@@ -647,5 +776,6 @@ abstract class DigressivePriceQuery extends ModelCriteria
             $con->rollBack();
             throw $e;
         }
-     }
+    }
+
 } // DigressivePriceQuery

--- a/Model/Map/DigressivePriceTableMap.php
+++ b/Model/Map/DigressivePriceTableMap.php
@@ -14,6 +14,7 @@ use Propel\Runtime\Map\RelationMap;
 use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Map\TableMapTrait;
 
+
 /**
  * This class defines the structure of the 'digressive_price' table.
  *
@@ -57,7 +58,7 @@ class DigressivePriceTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 6;
+    const NUM_COLUMNS = 7;
 
     /**
      * The number of lazy-loaded columns
@@ -67,7 +68,7 @@ class DigressivePriceTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 6;
+    const NUM_HYDRATE_COLUMNS = 7;
 
     /**
      * the column name for the ID field
@@ -78,6 +79,11 @@ class DigressivePriceTableMap extends TableMap
      * the column name for the PRODUCT_ID field
      */
     const PRODUCT_ID = 'digressive_price.PRODUCT_ID';
+
+    /**
+     * the column name for the PRODUCT_SALE_ELEMENTS_ID field
+     */
+    const PRODUCT_SALE_ELEMENTS_ID = 'digressive_price.PRODUCT_SALE_ELEMENTS_ID';
 
     /**
      * the column name for the PRICE field
@@ -110,13 +116,13 @@ class DigressivePriceTableMap extends TableMap
      * first dimension keys are the type constants
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
-    protected static $fieldNames = array(
-        self::TYPE_PHPNAME       => array('Id', 'ProductId', 'Price', 'PromoPrice', 'QuantityFrom', 'QuantityTo', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'productId', 'price', 'promoPrice', 'quantityFrom', 'quantityTo', ),
-        self::TYPE_COLNAME       => array(DigressivePriceTableMap::ID, DigressivePriceTableMap::PRODUCT_ID, DigressivePriceTableMap::PRICE, DigressivePriceTableMap::PROMO_PRICE, DigressivePriceTableMap::QUANTITY_FROM, DigressivePriceTableMap::QUANTITY_TO, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'PRODUCT_ID', 'PRICE', 'PROMO_PRICE', 'QUANTITY_FROM', 'QUANTITY_TO', ),
-        self::TYPE_FIELDNAME     => array('id', 'product_id', 'price', 'promo_price', 'quantity_from', 'quantity_to', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+    protected static $fieldNames = array (
+        self::TYPE_PHPNAME       => array('Id', 'ProductId', 'ProductSaleElementsId', 'Price', 'PromoPrice', 'QuantityFrom', 'QuantityTo', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'productId', 'productSaleElementsId', 'price', 'promoPrice', 'quantityFrom', 'quantityTo', ),
+        self::TYPE_COLNAME       => array(DigressivePriceTableMap::ID, DigressivePriceTableMap::PRODUCT_ID, DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID, DigressivePriceTableMap::PRICE, DigressivePriceTableMap::PROMO_PRICE, DigressivePriceTableMap::QUANTITY_FROM, DigressivePriceTableMap::QUANTITY_TO, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'PRODUCT_ID', 'PRODUCT_SALE_ELEMENTS_ID', 'PRICE', 'PROMO_PRICE', 'QUANTITY_FROM', 'QUANTITY_TO', ),
+        self::TYPE_FIELDNAME     => array('id', 'product_id', 'product_sale_elements_id', 'price', 'promo_price', 'quantity_from', 'quantity_to', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
     );
 
     /**
@@ -125,13 +131,13 @@ class DigressivePriceTableMap extends TableMap
      * first dimension keys are the type constants
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
-    protected static $fieldKeys = array(
-        self::TYPE_PHPNAME       => array('Id' => 0, 'ProductId' => 1, 'Price' => 2, 'PromoPrice' => 3, 'QuantityFrom' => 4, 'QuantityTo' => 5, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'productId' => 1, 'price' => 2, 'promoPrice' => 3, 'quantityFrom' => 4, 'quantityTo' => 5, ),
-        self::TYPE_COLNAME       => array(DigressivePriceTableMap::ID => 0, DigressivePriceTableMap::PRODUCT_ID => 1, DigressivePriceTableMap::PRICE => 2, DigressivePriceTableMap::PROMO_PRICE => 3, DigressivePriceTableMap::QUANTITY_FROM => 4, DigressivePriceTableMap::QUANTITY_TO => 5, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PRODUCT_ID' => 1, 'PRICE' => 2, 'PROMO_PRICE' => 3, 'QUANTITY_FROM' => 4, 'QUANTITY_TO' => 5, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'product_id' => 1, 'price' => 2, 'promo_price' => 3, 'quantity_from' => 4, 'quantity_to' => 5, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+    protected static $fieldKeys = array (
+        self::TYPE_PHPNAME       => array('Id' => 0, 'ProductId' => 1, 'ProductSaleElementsId' => 2, 'Price' => 3, 'PromoPrice' => 4, 'QuantityFrom' => 5, 'QuantityTo' => 6, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'productId' => 1, 'productSaleElementsId' => 2, 'price' => 3, 'promoPrice' => 4, 'quantityFrom' => 5, 'quantityTo' => 6, ),
+        self::TYPE_COLNAME       => array(DigressivePriceTableMap::ID => 0, DigressivePriceTableMap::PRODUCT_ID => 1, DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID => 2, DigressivePriceTableMap::PRICE => 3, DigressivePriceTableMap::PROMO_PRICE => 4, DigressivePriceTableMap::QUANTITY_FROM => 5, DigressivePriceTableMap::QUANTITY_TO => 6, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'PRODUCT_ID' => 1, 'PRODUCT_SALE_ELEMENTS_ID' => 2, 'PRICE' => 3, 'PROMO_PRICE' => 4, 'QUANTITY_FROM' => 5, 'QUANTITY_TO' => 6, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'product_id' => 1, 'product_sale_elements_id' => 2, 'price' => 3, 'promo_price' => 4, 'quantity_from' => 5, 'quantity_to' => 6, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, )
     );
 
     /**
@@ -152,6 +158,7 @@ class DigressivePriceTableMap extends TableMap
         // columns
         $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
         $this->addForeignKey('PRODUCT_ID', 'ProductId', 'INTEGER', 'product', 'ID', true, null, null);
+        $this->addForeignKey('PRODUCT_SALE_ELEMENTS_ID', 'ProductSaleElementsId', 'INTEGER', 'product_sale_elements', 'ID', false, null, null);
         $this->addColumn('PRICE', 'Price', 'FLOAT', true, null, null);
         $this->addColumn('PROMO_PRICE', 'PromoPrice', 'FLOAT', true, null, null);
         $this->addColumn('QUANTITY_FROM', 'QuantityFrom', 'INTEGER', true, null, null);
@@ -164,6 +171,7 @@ class DigressivePriceTableMap extends TableMap
     public function buildRelations()
     {
         $this->addRelation('Product', '\\DigressivePrice\\Model\\Thelia\\Model\\Product', RelationMap::MANY_TO_ONE, array('product_id' => 'id', ), null, null);
+        $this->addRelation('ProductSaleElements', '\\DigressivePrice\\Model\\Thelia\\Model\\ProductSaleElements', RelationMap::MANY_TO_ONE, array('product_sale_elements_id' => 'id', ), null, null);
     } // buildRelations()
 
     /**
@@ -201,7 +209,8 @@ class DigressivePriceTableMap extends TableMap
      */
     public static function getPrimaryKeyFromRow($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
     {
-        return (int) $row[
+
+            return (int) $row[
                             $indexType == TableMap::TYPE_NUM
                             ? 0 + $offset
                             : self::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)
@@ -305,6 +314,7 @@ class DigressivePriceTableMap extends TableMap
         if (null === $alias) {
             $criteria->addSelectColumn(DigressivePriceTableMap::ID);
             $criteria->addSelectColumn(DigressivePriceTableMap::PRODUCT_ID);
+            $criteria->addSelectColumn(DigressivePriceTableMap::PRODUCT_SALE_ELEMENTS_ID);
             $criteria->addSelectColumn(DigressivePriceTableMap::PRICE);
             $criteria->addSelectColumn(DigressivePriceTableMap::PROMO_PRICE);
             $criteria->addSelectColumn(DigressivePriceTableMap::QUANTITY_FROM);
@@ -312,6 +322,7 @@ class DigressivePriceTableMap extends TableMap
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.PRODUCT_ID');
+            $criteria->addSelectColumn($alias . '.PRODUCT_SALE_ELEMENTS_ID');
             $criteria->addSelectColumn($alias . '.PRICE');
             $criteria->addSelectColumn($alias . '.PROMO_PRICE');
             $criteria->addSelectColumn($alias . '.QUANTITY_FROM');
@@ -336,10 +347,10 @@ class DigressivePriceTableMap extends TableMap
      */
     public static function buildTableMap()
     {
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap(DigressivePriceTableMap::DATABASE_NAME);
-        if (!$dbMap->hasTable(DigressivePriceTableMap::TABLE_NAME)) {
-            $dbMap->addTableObject(new DigressivePriceTableMap());
-        }
+      $dbMap = Propel::getServiceContainer()->getDatabaseMap(DigressivePriceTableMap::DATABASE_NAME);
+      if (!$dbMap->hasTable(DigressivePriceTableMap::TABLE_NAME)) {
+        $dbMap->addTableObject(new DigressivePriceTableMap());
+      }
     }
 
     /**
@@ -355,33 +366,31 @@ class DigressivePriceTableMap extends TableMap
      */
      public static function doDelete($values, ConnectionInterface $con = null)
      {
-         if (null === $con) {
-             $con = Propel::getServiceContainer()->getWriteConnection(DigressivePriceTableMap::DATABASE_NAME);
-         }
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(DigressivePriceTableMap::DATABASE_NAME);
+        }
 
-         if ($values instanceof Criteria) {
-             // rename for clarity
+        if ($values instanceof Criteria) {
+            // rename for clarity
             $criteria = $values;
-         } elseif ($values instanceof \DigressivePrice\Model\DigressivePrice) { // it's a model object
+        } elseif ($values instanceof \DigressivePrice\Model\DigressivePrice) { // it's a model object
             // create criteria based on pk values
             $criteria = $values->buildPkeyCriteria();
-         } else { // it's a primary key, or an array of pks
+        } else { // it's a primary key, or an array of pks
             $criteria = new Criteria(DigressivePriceTableMap::DATABASE_NAME);
-             $criteria->add(DigressivePriceTableMap::ID, (array) $values, Criteria::IN);
-         }
+            $criteria->add(DigressivePriceTableMap::ID, (array) $values, Criteria::IN);
+        }
 
-         $query = DigressivePriceQuery::create()->mergeWith($criteria);
+        $query = DigressivePriceQuery::create()->mergeWith($criteria);
 
-         if ($values instanceof Criteria) {
-             DigressivePriceTableMap::clearInstancePool();
-         } elseif (!is_object($values)) { // it's a primary key, or an array of pks
-            foreach ((array) $values as $singleval) {
-                DigressivePriceTableMap::removeInstanceFromPool($singleval);
+        if ($values instanceof Criteria) { DigressivePriceTableMap::clearInstancePool();
+        } elseif (!is_object($values)) { // it's a primary key, or an array of pks
+            foreach ((array) $values as $singleval) { DigressivePriceTableMap::removeInstanceFromPool($singleval);
             }
-         }
+        }
 
-         return $query->delete($con);
-     }
+        return $query->delete($con);
+    }
 
     /**
      * Deletes all rows from the digressive_price table.
@@ -415,7 +424,7 @@ class DigressivePriceTableMap extends TableMap
             $criteria = $criteria->buildCriteria(); // build Criteria from DigressivePrice object
         }
 
-        if ($criteria->containsKey(DigressivePriceTableMap::ID) && $criteria->keyContainsValue(DigressivePriceTableMap::ID)) {
+        if ($criteria->containsKey(DigressivePriceTableMap::ID) && $criteria->keyContainsValue(DigressivePriceTableMap::ID) ) {
             throw new PropelException('Cannot insert a value for auto-increment primary key ('.DigressivePriceTableMap::ID.')');
         }
 
@@ -436,6 +445,7 @@ class DigressivePriceTableMap extends TableMap
 
         return $pk;
     }
+
 } // DigressivePriceTableMap
 // This is the static code needed to register the TableMap for this table with the main Propel class.
 //

--- a/readme.md
+++ b/readme.md
@@ -59,20 +59,22 @@ The Hook used is called "product.tab-content".
 
 |Argument |Description |
 |---      |--- |
-|**product_id** | The ID of the product to get digressive prices. Example: "product_id=3" |
+|**product_id**               | The ID of the product to get digressive prices. Example: "product_id=3" |
+|**product_sale_elements_id** | The ID of the product sale elements to get digressive prices. Example: "product_sale_elements_id=6" |
 
 ### Output arguments
 
 |Variable   |Description |
 |---        |--- |
-|$ID                | The digressive price range's ID |
-|$PRODUCT_ID        | The product which th current digressive price is linked to |
-|$QUANTITY_FROM     | The quantity beginning of the range of the digressive price |
-|$QUANTITY_TO       | The quantity ending of the range of the digressive price |
-|$PRICE             | The tax free price of the product if the quantity is in the range |
-|$PROMO_PRICE       | The promo tax free price of the product if the quantity is in the range |
-|$TAXED_PRICE       | The taxed price of the product. Uses the tax rules of the user's country |
-|$TAXED_PROMO_PRICE | The taxed promo price of the product. Uses the tax rules of the user's country |
+|$ID                       | The digressive price range's ID |
+|$PRODUCT_ID               | The product which th current digressive price is linked to |
+|$PRODUCT_SALE_ELEMENTS_ID | The product sale elements the current digressive price is linked to |
+|$QUANTITY_FROM            | The quantity beginning of the range of the digressive price |
+|$QUANTITY_TO              | The quantity ending of the range of the digressive price |
+|$PRICE                    | The tax free price of the product if the quantity is in the range |
+|$PROMO_PRICE              | The promo tax free price of the product if the quantity is in the range |
+|$TAXED_PRICE              | The taxed price of the product. Uses the tax rules of the user's country |
+|$TAXED_PROMO_PRICE        | The taxed promo price of the product. Uses the tax rules of the user's country |
 
 ### Example
 

--- a/templates/backOffice/default/product-tab-content-hook.html
+++ b/templates/backOffice/default/product-tab-content-hook.html
@@ -11,6 +11,7 @@
         <table class="table table-hover">
             <thead>
                 <tr>
+                    <th>{intl l="Attribute combination" d="digressiveprice.bo.default"}</th>
                     <th>{intl l="From" d="digressiveprice.bo.default"}</th>
                     <th>{intl l="To" d="digressiveprice.bo.default"}</th>
                     <th>{intl l="Price w/o taxes" d="digressiveprice.bo.default"}</th>
@@ -36,6 +37,23 @@
                         {form_field form=$form field="productId"}
                         <input type="hidden" name="{$name}" value="{$PRODUCT_ID}">
                         {/form_field}
+
+                        <!-- Attribute combination -->
+                        <td>
+                            {form_field form=$form field="productSaleElementsId"}
+                            {$selected_pse = $PRODUCT_SALE_ELEMENTS_ID}
+                            <select name="{$name}" class="form-control">
+                                <option value="" {if not $selected_pse}selected{/if}>{intl l="All" d="digressiveprice.bo.default"}</option>
+                                {loop name="productSaleElements" type="product_sale_elements" product={$PRODUCT_ID} backend_context="1"}
+                                    <option value="{$ID}" {if $ID == $selected_pse}selected{/if}>
+                                    {loop name="productSaleElementsAttributes" type="attribute_combination" product_sale_elements=$ID backend_context="1"}
+                                       {if $LOOP_COUNT > 1} / {/if}{$ATTRIBUTE_TITLE}: {$ATTRIBUTE_AVAILABILITY_TITLE}
+                                    {/loop}
+                                    </option>
+                                {/loop}
+                            </select>
+                            {/form_field}
+                        </td>
 
                         <!-- Quantities -->
                         <td>
@@ -99,6 +117,22 @@
                         {form_field form=$form field="productId"}
                         <input type="hidden" name="{$name}" value="{product attr='id'}">
                         {/form_field}
+
+                        <!-- Attribute combination -->
+                        <td>
+                            {form_field form=$form field="productSaleElementsId"}
+                            <select name="{$name}" class="form-control">
+                                <option value="" >{intl l="All" d="digressiveprice.bo.default"}</option>
+                                {loop name="productSaleElements" type="product_sale_elements" product={product attr='id'} backend_context="1"}
+                                    <option value="{$ID}">
+                                    {loop name="productSaleElementsAttributes" type="attribute_combination" product_sale_elements=$ID backend_context="1"}
+                                       {if $LOOP_COUNT > 1} / {/if}{$ATTRIBUTE_TITLE}: {$ATTRIBUTE_AVAILABILITY_TITLE}
+                                    {/loop}
+                                    </option>
+                                {/loop}
+                            </select>
+                            {/form_field}
+                        </td>
 
                         <!-- Quantities -->
                         <td>


### PR DESCRIPTION
Added pse-specific degressive prices ranges. A pse can be now optionally be chosen when creating a degressive price range (default to all pse, which is the same behavior as before).

When setting the reduced price for a product, pse-specific ranges will be considered first, before all-pse ranges.

Updating from previous module versions require a database update:

``` SQL
ALTER TABLE `digressive_price` ADD COLUMN `product_sale_elements_id INT;
ALTER TABLE `digressive_price`
    ADD CONSTRAINT `fk_product_sale_elements_digressive`
        FOREIGN KEY (`product_sale_elements_id`)
        REFERENCES `product_sale_elements` (`id`);
```
